### PR TITLE
Continuations without public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,13 @@ The task extension exposes a public API that can be used to create, run and inte
 
 ### Awaitable
 
-Interface that is exposed to userland classes by async operations that can be awaited by tasks. The `$continuation` callback takes a `Throwable` as first argument when the operation has failed (second argument must be optional), successful operations pass `null` as first argument and the result as second argument.
+This interface cannot be implemented directly by userland classes, implementations are provided by `Deferred` and `Task`.
 
 ```php
 namespace Concurrent;
 
-interface Awaitable
-{
-    public function continueWith(callable(?\Throwable, mixed = null) $continuation): void;
-}
+interface Awaitable { }
 ```
-
-This interface cannot be implemented directly by userland classes, implementations are provided by `Deferred` and `Task`.
 
 ### Deferred
 
@@ -34,7 +29,7 @@ final class Deferred
     
     public function awaitable(): Awaitable { }
     
-    public function succeed($val = null): void { }
+    public function resolve($val = null): void { }
     
     public function fail(\Throwable $e): void { }
 }
@@ -49,8 +44,6 @@ namespace Concurrent;
 
 final class Task implements Awaitable
 {
-    public function continueWith(callable(?\Throwable, mixed = null) $continuation): void { }
-    
     public static function isRunning(): bool { }
     
     /* Should be replaced with async keyword if merged into PHP core. */
@@ -79,7 +72,7 @@ namespace Concurrent;
 
 final class TaskScheduler implements \Countable
 {
-    public function __construct(?array $context = null, ?callable(\Throwable) $errorHandler = null) { }
+    public function __construct(?array $context = null) { }
 
     public function count(): int { }
     
@@ -112,8 +105,6 @@ final class Context
     
     public function without(string $var): Context { }
 
-    public function withErrorHandler(callable $handler): Context { }
-    
     public function run(callable $callback, ...$args): mixed { }
     
     public static function var(string $name): mixed { }

--- a/examples/a.php
+++ b/examples/a.php
@@ -9,19 +9,12 @@ $scheduler = new TaskScheduler();
 $scheduler->task(function (): int {
     $t = Task::async(function (): int {
         $defer = new Deferred();
-        
-        $defer->awaitable()->continueWith(function (?\Throwable $e, $v = null) {
-            var_dump('DEFERRED', $e, $v);
-        });
-        
         $defer->succeed(321);
         
         return max(123, Task::await($defer->awaitable()));
     });
     
-    return 2 * Task::await($t);
-})->continueWith(function (?\Throwable $e, ?int $v = null): void {
-    var_dump('CONTINUE WITH', $e, $v);
+    var_dump(2 * Task::await($t));
 });
 
 $scheduler->run();

--- a/examples/d.php
+++ b/examples/d.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Concurrent;
+
+error_reporting(-1);
+ini_set('display_errors', '1');
+
+$scheduler = new TaskScheduler();
+
+$scheduler->task(function () {
+    $defer = new Deferred();
+
+    $t = Task::async(function () use ($defer) {
+        var_dump('INNER DONE!');
+        $defer->resolve(777);
+        return 777;
+    });
+    var_dump('ICKE!');
+    var_dump(Task::await($defer->awaitable()));
+    var_dump(Task::await($t));
+    var_dump('OUTER DONE!');
+});
+
+$scheduler->run();

--- a/examples/stub.php
+++ b/examples/stub.php
@@ -2,10 +2,7 @@
 
 namespace Concurrent;
 
-interface Awaitable
-{
-    public function continueWith(callable $continuation): void;
-}
+interface Awaitable { }
 
 final class Context
 {
@@ -14,8 +11,6 @@ final class Context
     public function with(string $var, $value): Context { }
     
     public function without(string $var): Context { }
-    
-    public function withErrorHandler(callable $handler): Context { }
     
     public function run(callable $callback, ...$args) { }
     
@@ -34,20 +29,15 @@ final class Deferred
     
     public function awaitable(): Awaitable { }
     
-    public function succeed($val = null): void { }
+    public function resolve($val = null): void { }
     
     public function fail(\Throwable $e): void { }
 }
 
-final class DeferredAwaitable implements Awaitable
-{
-    public function continueWith(callable $continuation): void { }
-}
+final class DeferredAwaitable implements Awaitable { }
 
 final class Task implements Awaitable
 {
-    public function continueWith(callable $continuation): void { }
-    
     public static function isRunning(): bool { }
     
     public static function async(callable $callback, ?array $args = null): Task { }
@@ -57,14 +47,9 @@ final class Task implements Awaitable
     public static function await($a) { }
 }
 
-final class TaskContinuation
-{
-    public function __invoke(?\Throwable $e, $v = null) { }
-}
-
 final class TaskScheduler implements \Countable
 {
-    public function __construct(?array $context = null, ?callable $errorHandler = null) { }
+    public function __construct(?array $context = null) { }
 
     public function count(): int { }
     

--- a/include/awaitable.h
+++ b/include/awaitable.h
@@ -25,6 +25,20 @@ BEGIN_EXTERN_C()
 
 extern zend_class_entry *concurrent_awaitable_ce;
 
+typedef struct _concurrent_awaitable_cb concurrent_awaitable_cb;
+
+typedef void (* concurrent_awaitable_func)(void *obj, zval *result, zend_bool success);
+
+struct _concurrent_awaitable_cb {
+	void *object;
+	concurrent_awaitable_func func;
+	concurrent_awaitable_cb *next;
+};
+
+concurrent_awaitable_cb *concurrent_awaitable_create_continuation(void *obj, concurrent_awaitable_func func);
+void concurrent_awaitable_append_continuation(concurrent_awaitable_cb *prev, void *obj, concurrent_awaitable_func func);
+void concurrent_awaitable_trigger_continuation(concurrent_awaitable_cb *cont, zval *result, zend_bool success);
+
 void concurrent_awaitable_ce_register();
 
 END_EXTERN_C()

--- a/include/context.h
+++ b/include/context.h
@@ -22,7 +22,6 @@
 #include "php.h"
 
 typedef struct _concurrent_task_scheduler concurrent_task_scheduler;
-typedef struct _concurrent_context_error_handler concurrent_context_error_handler;
 
 BEGIN_EXTERN_C()
 
@@ -37,8 +36,6 @@ struct _concurrent_context {
 
 	concurrent_task_scheduler *scheduler;
 
-	concurrent_context_error_handler *error_handler;
-
 	uint32_t param_count;
 
 	union {
@@ -50,17 +47,11 @@ struct _concurrent_context {
 	} data;
 };
 
-void concurrent_context_delegate_error(concurrent_context *context);
 concurrent_context *concurrent_context_object_create(HashTable *params);
 
 void concurrent_context_ce_register();
 
 END_EXTERN_C()
-
-struct _concurrent_context_error_handler {
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcc;
-};
 
 #endif
 

--- a/include/deferred.h
+++ b/include/deferred.h
@@ -20,9 +20,7 @@
 #define CONCURRENT_DEFERRED_H
 
 #include "php.h"
-
-typedef struct _concurrent_deferred_awaitable concurrent_deferred_awaitable;
-typedef struct _concurrent_deferred_continuation_cb concurrent_deferred_continuation_cb;
+#include "awaitable.h"
 
 BEGIN_EXTERN_C()
 
@@ -30,6 +28,7 @@ extern zend_class_entry *concurrent_deferred_ce;
 extern zend_class_entry *concurrent_deferred_awaitable_ce;
 
 typedef struct _concurrent_deferred concurrent_deferred;
+typedef struct _concurrent_deferred_awaitable concurrent_deferred_awaitable;
 
 struct _concurrent_deferred {
 	zend_object std;
@@ -40,16 +39,13 @@ struct _concurrent_deferred {
 
 	zval result;
 
-	concurrent_deferred_continuation_cb *continuation;
+	/* Linked list of registered continuation callbacks. */
+	concurrent_awaitable_cb *continuation;
 };
 
 extern const zend_uchar CONCURRENT_DEFERRED_STATUS_PENDING;
 extern const zend_uchar CONCURRENT_DEFERRED_STATUS_SUCCEEDED;
 extern const zend_uchar CONCURRENT_DEFERRED_STATUS_FAILED;
-
-void concurrent_deferred_ce_register();
-
-END_EXTERN_C()
 
 struct _concurrent_deferred_awaitable {
 	zend_object std;
@@ -57,14 +53,9 @@ struct _concurrent_deferred_awaitable {
 	concurrent_deferred *defer;
 };
 
-struct _concurrent_deferred_continuation_cb {
-	/* Callback and info / cache of an continuation callback. */
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcc;
+void concurrent_deferred_ce_register();
 
-	/* Points to next callback, NULL if this is the last callback. */
-	concurrent_deferred_continuation_cb *next;
-};
+END_EXTERN_C()
 
 #endif
 

--- a/include/task.h
+++ b/include/task.h
@@ -20,9 +20,7 @@
 #define CONCURRENT_TASK_H
 
 #include "php.h"
-
-typedef struct _concurrent_task_continuation concurrent_task_continuation;
-typedef struct _concurrent_task_continuation_cb concurrent_task_continuation_cb;
+#include "awaitable.h"
 
 typedef void* concurrent_fiber_context;
 typedef struct _concurrent_context concurrent_context;
@@ -57,7 +55,7 @@ struct _concurrent_task {
 	zval result;
 
 	/* Linked list of registered continuation callbacks. */
-	concurrent_task_continuation_cb *continuation;
+	concurrent_awaitable_cb *continuation;
 };
 
 extern const zend_uchar CONCURRENT_FIBER_TYPE_TASK;
@@ -71,29 +69,9 @@ concurrent_task *concurrent_task_object_create();
 void concurrent_task_start(concurrent_task *task);
 void concurrent_task_continue(concurrent_task *task);
 
-void concurrent_task_notify_success(concurrent_task *task);
-void concurrent_task_notify_failure(concurrent_task *task);
-
 void concurrent_task_ce_register();
 
 END_EXTERN_C()
-
-struct _concurrent_task_continuation {
-	/* Task PHP object handle. */
-	zend_object std;
-
-	/* The task to be scheduled. */
-	concurrent_task *task;
-};
-
-struct _concurrent_task_continuation_cb {
-	/* Callback and info / cache of an continuation callback. */
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcc;
-
-	/* Points to next callback, NULL if this is the last callback. */
-	concurrent_task_continuation_cb *next;
-};
 
 #endif
 

--- a/src/task.c
+++ b/src/task.c
@@ -28,7 +28,6 @@
 ZEND_DECLARE_MODULE_GLOBALS(task)
 
 zend_class_entry *concurrent_task_ce;
-zend_class_entry *concurrent_task_continuation_ce;
 
 const zend_uchar CONCURRENT_FIBER_TYPE_TASK = 1;
 
@@ -37,9 +36,6 @@ const zend_uchar CONCURRENT_TASK_OPERATION_START = 1;
 const zend_uchar CONCURRENT_TASK_OPERATION_RESUME = 2;
 
 static zend_object_handlers concurrent_task_handlers;
-static zend_object_handlers concurrent_task_continuation_handlers;
-
-static zend_object *concurrent_task_continuation_object_create(concurrent_task *task);
 
 
 void concurrent_task_start(concurrent_task *task)
@@ -88,97 +84,28 @@ void concurrent_task_continue(concurrent_task *task)
 	}
 }
 
-void concurrent_task_notify_success(concurrent_task *task)
+static void concurrent_task_continuation(void *obj, zval *result, zend_bool success)
 {
-	concurrent_task_continuation_cb *cont;
-	concurrent_context *context;
+	concurrent_task *task;
 
-	zval args[2];
-	zval retval;
+	task = (concurrent_task *) obj;
 
-	context = TASK_G(current_context);
-	TASK_G(current_context) = task->context;
+	ZEND_ASSERT(task->fiber.status == CONCURRENT_FIBER_STATUS_SUSPENDED);
 
-	while (task->continuation != NULL) {
-		cont = task->continuation;
-		task->continuation = cont->next;
-
-		ZVAL_NULL(&args[0]);
-		ZVAL_COPY(&args[1], &task->result);
-
-		cont->fci.param_count = 2;
-		cont->fci.params = args;
-		cont->fci.retval = &retval;
-
-		zend_call_function(&cont->fci, &cont->fcc);
-
-		zval_ptr_dtor(args);
-		zval_ptr_dtor(&retval);
-		zval_ptr_dtor(&cont->fci.function_name);
-
-		efree(cont);
-
-		if (UNEXPECTED(EG(exception))) {
-			concurrent_context_delegate_error(task->context);
+	if (success) {
+		if (task->fiber.value != NULL) {
+			ZVAL_COPY(task->fiber.value, result);
 		}
-	}
-
-	TASK_G(current_context) = context;
-}
-
-void concurrent_task_notify_failure(concurrent_task *task)
-{
-	concurrent_task_continuation_cb *cont;
-	concurrent_context *context;
-
-	zval args[1];
-	zval retval;
-
-	context = TASK_G(current_context);
-	TASK_G(current_context) = task->context;
-
-	while (task->continuation != NULL) {
-		cont = task->continuation;
-		task->continuation = cont->next;
-
-		ZVAL_COPY(&args[0], &task->result);
-
-		cont->fci.param_count = 1;
-		cont->fci.params = args;
-		cont->fci.retval = &retval;
-
-		zend_call_function(&cont->fci, &cont->fcc);
-
-		zval_ptr_dtor(args);
-		zval_ptr_dtor(&retval);
-		zval_ptr_dtor(&cont->fci.function_name);
-
-		efree(cont);
-
-		if (UNEXPECTED(EG(exception))) {
-			concurrent_context_delegate_error(task->context);
-		}
-	}
-
-	TASK_G(current_context) = context;
-}
-
-static void concurrent_task_dispose(concurrent_task *task)
-{
-	task->fiber.status = CONCURRENT_FIBER_STATUS_DEAD;
-
-	concurrent_fiber_switch_to(&task->fiber);
-
-	if (UNEXPECTED(EG(exception))) {
-		ZVAL_OBJ(&task->result, EG(exception));
-		EG(exception) = NULL;
-
-		concurrent_task_notify_failure(task);
 	} else {
-		concurrent_task_notify_success(task);
+		ZVAL_COPY(&task->error, result);
 	}
-}
 
+	task->fiber.value = NULL;
+
+	concurrent_task_scheduler_enqueue(task);
+
+	OBJ_RELEASE(&task->fiber.std);
+}
 
 concurrent_task *concurrent_task_object_create()
 {
@@ -217,7 +144,6 @@ concurrent_task *concurrent_task_object_create()
 static void concurrent_task_object_destroy(zend_object *object)
 {
 	concurrent_task *task;
-	concurrent_task_continuation_cb *cont;
 
 	task = (concurrent_task *) object;
 
@@ -233,17 +159,12 @@ static void concurrent_task_object_destroy(zend_object *object)
 		zval_ptr_dtor(&task->fiber.fci.function_name);
 	}
 
+	if (task->continuation != NULL) {
+		concurrent_awaitable_trigger_continuation(task->continuation, &task->result, 0);
+	}
+
 	zval_ptr_dtor(&task->result);
 	zval_ptr_dtor(&task->error);
-
-	while (task->continuation != NULL) {
-		cont = task->continuation;
-		task->continuation = cont->next;
-
-		zval_ptr_dtor(&cont->fci.function_name);
-
-		efree(cont);
-	}
 
 	OBJ_RELEASE(&task->context->std);
 
@@ -257,82 +178,6 @@ ZEND_METHOD(Task, __construct)
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	zend_throw_error(NULL, "Tasks must not be constructed by userland code");
-}
-
-ZEND_METHOD(Task, continueWith)
-{
-	concurrent_task *task;
-	concurrent_task_continuation_cb *cont;
-	concurrent_task_continuation_cb *tmp;
-
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcc;
-	zval args[2];
-	zval result;
-
-	task = (concurrent_task *) Z_OBJ_P(getThis());
-
-	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1)
-		Z_PARAM_FUNC_EX(fci, fcc, 1, 0)
-	ZEND_PARSE_PARAMETERS_END();
-
-	fci.no_separation = 1;
-
-	if (task->fiber.status == CONCURRENT_FIBER_STATUS_FINISHED) {
-		ZVAL_NULL(&args[0]);
-		ZVAL_COPY(&args[1], &task->result);
-
-		fci.param_count = 2;
-		fci.params = args;
-		fci.retval = &result;
-
-		zend_call_function(&fci, &fcc);
-		zval_ptr_dtor(args);
-		zval_ptr_dtor(&result);
-
-		if (UNEXPECTED(EG(exception))) {
-			concurrent_context_delegate_error(task->context);
-		}
-
-		return;
-	}
-
-	if (task->fiber.status == CONCURRENT_FIBER_STATUS_DEAD) {
-		ZVAL_COPY(&args[0], &task->result);
-
-		fci.param_count = 1;
-		fci.params = args;
-		fci.retval = &result;
-
-		zend_call_function(&fci, &fcc);
-		zval_ptr_dtor(args);
-		zval_ptr_dtor(&result);
-
-		if (UNEXPECTED(EG(exception))) {
-			concurrent_context_delegate_error(task->context);
-		}
-
-		return;
-	}
-
-	cont = emalloc(sizeof(concurrent_task_continuation_cb));
-	cont->fci = fci;
-	cont->fcc = fcc;
-	cont->next = NULL;
-
-	if (task->continuation == NULL) {
-		task->continuation = cont;
-	} else {
-		tmp = task->continuation;
-
-		while (tmp->next != NULL) {
-			tmp = tmp->next;
-		}
-
-		tmp->next = cont;
-	}
-
-	Z_TRY_ADDREF_P(&fci.function_name);
 }
 
 ZEND_METHOD(Task, isRunning)
@@ -440,19 +285,17 @@ ZEND_METHOD(Task, await)
 	zend_class_entry *ce;
 	concurrent_task *task;
 	concurrent_task *inner;
+	concurrent_deferred *defer;
 	concurrent_context *context;
 	concurrent_task_scheduler *scheduler;
-	zend_execute_data *exec;
 	size_t stack_page_size;
 
 	zval *val;
-	zval retval;
-	zval cont;
-	zval error;
 	zval *value;
+	zval error;
 
 	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1)
-		Z_PARAM_ZVAL(val);
+		Z_PARAM_ZVAL(val)
 	ZEND_PARSE_PARAMETERS_END();
 
 	task = (concurrent_task *) TASK_G(current_fiber);
@@ -477,109 +320,55 @@ ZEND_METHOD(Task, await)
 
 	ce = Z_OBJCE_P(val);
 
-	// Optimized handling of awaited tasks.
 	if (ce == concurrent_task_ce) {
 		inner = (concurrent_task *) Z_OBJ_P(val);
-
-		// Task-inlining optimization, avoids allocating a native fiber and stack for the awaited task.
-		if (inner->fiber.status == CONCURRENT_FIBER_STATUS_INIT && inner->fiber.stack_size == task->fiber.stack_size) {
-			if (inner->context->scheduler == scheduler) {
-				inner->operation = CONCURRENT_TASK_OPERATION_NONE;
-
-				context = TASK_G(current_context);
-				TASK_G(current_context) = inner->context;
-
-				inner->fiber.fci.retval = &inner->result;
-
-				zend_call_function(&inner->fiber.fci, &inner->fiber.fcc);
-
-				zval_ptr_dtor(&inner->fiber.fci.function_name);
-				zend_fcall_info_args_clear(&inner->fiber.fci, 1);
-
-				TASK_G(current_context) = context;
-
-				if (UNEXPECTED(EG(exception))) {
-					inner->fiber.status = CONCURRENT_FIBER_STATUS_DEAD;
-
-					ZVAL_OBJ(&inner->result, EG(exception));
-					EG(exception) = NULL;
-
-					concurrent_task_notify_failure(inner);
-				} else {
-					inner->fiber.status = CONCURRENT_FIBER_STATUS_FINISHED;
-
-					concurrent_task_notify_success(inner);
-				}
-			}
-		}
 
 		if (inner->fiber.status == CONCURRENT_FIBER_STATUS_FINISHED) {
 			RETURN_ZVAL(&inner->result, 1, 0);
 		}
 
 		if (inner->fiber.status == CONCURRENT_FIBER_STATUS_DEAD) {
-			exec = EG(current_execute_data);
-
-			exec->opline--;
+			execute_data->opline--;
 			zend_throw_exception_internal(&inner->result);
-			exec->opline++;
+			execute_data->opline++;
 
 			return;
 		}
-	}
 
-	// Attempt to adapt non-awaitable objects to awaitables.
-	if (instanceof_function_ex(ce, concurrent_awaitable_ce, 1) != 1) {
-		if (scheduler->adapter) {
-			scheduler->adapter_fci.param_count = 1;
-			scheduler->adapter_fci.params = val;
-			scheduler->adapter_fci.retval = &retval;
+		if (inner->continuation == NULL) {
+			inner->continuation = concurrent_awaitable_create_continuation(task, concurrent_task_continuation);
+		} else {
+			concurrent_awaitable_append_continuation(inner->continuation, task, concurrent_task_continuation);
+		}
+	} else if (ce == concurrent_deferred_awaitable_ce) {
+		defer = ((concurrent_deferred_awaitable *) Z_OBJ_P(val))->defer;
 
-			zend_call_function(&scheduler->adapter_fci, &scheduler->adapter_fcc);
-			zval_ptr_dtor(val);
-
-			ZVAL_COPY(val, &retval);
-			zval_ptr_dtor(&retval);
-
-			if (Z_TYPE_P(val) != IS_OBJECT) {
-				RETURN_ZVAL(val, 1, 0);
-			}
-
-			ce = Z_OBJCE_P(val);
+		if (defer->status == CONCURRENT_DEFERRED_STATUS_SUCCEEDED) {
+			RETURN_ZVAL(&defer->result, 1, 0);
 		}
 
-		if (instanceof_function_ex(ce, concurrent_awaitable_ce, 1) != 1) {
-			RETURN_ZVAL(val, 1, 0);
+		if (defer->status == CONCURRENT_DEFERRED_STATUS_FAILED) {
+			execute_data->opline--;
+			zend_throw_exception_internal(&defer->result);
+			execute_data->opline++;
+
+			return;
 		}
+
+		if (defer->continuation == NULL) {
+			defer->continuation = concurrent_awaitable_create_continuation(task, concurrent_task_continuation);
+		} else {
+			concurrent_awaitable_append_continuation(defer->continuation, task, concurrent_task_continuation);
+		}
+	} else {
+		RETURN_ZVAL(val, 1, 0);
 	}
 
-	value = task->fiber.value;
+	GC_ADDREF(&task->fiber.std);
 
 	// Switch the value pointer to the return value of await() until the task is continued.
+	value = task->fiber.value;
 	task->fiber.value = USED_RET() ? return_value : NULL;
-
-	ZVAL_OBJ(&cont, concurrent_task_continuation_object_create(task));
-	zend_call_method_with_1_params(val, NULL, NULL, "continueWith", NULL, &cont);
-	zval_ptr_dtor(&cont);
-
-	// Resume without fiber context switch if the awaitable is already resolved.
-	if (task->operation == CONCURRENT_TASK_OPERATION_RESUME) {
-		task->operation = CONCURRENT_TASK_OPERATION_NONE;
-		task->fiber.value = value;
-
-		if (Z_TYPE_P(&task->error) != IS_UNDEF) {
-			error = task->error;
-			ZVAL_UNDEF(&task->error);
-
-			exec = EG(current_execute_data);
-
-			exec->opline--;
-			zend_throw_exception_internal(&error);
-			exec->opline++;
-		}
-
-		return;
-	}
 
 	task->fiber.status = CONCURRENT_FIBER_STATUS_SUSPENDED;
 
@@ -602,11 +391,9 @@ ZEND_METHOD(Task, await)
 		error = task->error;
 		ZVAL_UNDEF(&task->error);
 
-		exec = EG(current_execute_data);
-
-		exec->opline--;
+		execute_data->opline--;
 		zend_throw_exception_internal(&error);
-		exec->opline++;
+		execute_data->opline++;
 	}
 }
 
@@ -618,10 +405,6 @@ ZEND_METHOD(Task, __wakeup)
 }
 
 ZEND_BEGIN_ARG_INFO(arginfo_task_ctor, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_task_continue_with, 0, 0, 1)
-	ZEND_ARG_CALLABLE_INFO(0, continuation, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_task_is_running, 0, 0, _IS_BOOL, 0)
@@ -647,124 +430,11 @@ ZEND_END_ARG_INFO()
 
 static const zend_function_entry task_functions[] = {
 	ZEND_ME(Task, __construct, arginfo_task_ctor, ZEND_ACC_PRIVATE | ZEND_ACC_CTOR)
-	ZEND_ME(Task, continueWith, arginfo_task_continue_with, ZEND_ACC_PUBLIC)
 	ZEND_ME(Task, isRunning, arginfo_task_is_running, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	ZEND_ME(Task, async, arginfo_task_async, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	ZEND_ME(Task, asyncWithContext, arginfo_task_async_with_context, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	ZEND_ME(Task, await, arginfo_task_await, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	ZEND_ME(Task, __wakeup, arginfo_task_wakeup, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-
-static zend_object *concurrent_task_continuation_object_create(concurrent_task *task)
-{
-	concurrent_task_continuation *cont;
-
-	cont = emalloc(sizeof(concurrent_task_continuation));
-	ZEND_SECURE_ZERO(cont, sizeof(concurrent_task_continuation));
-
-	cont->task = task;
-
-	GC_ADDREF(&task->fiber.std);
-
-	zend_object_std_init(&cont->std, concurrent_task_continuation_ce);
-	cont->std.handlers = &concurrent_task_continuation_handlers;
-
-	return &cont->std;
-}
-
-static void concurrent_task_continuation_object_destroy(zend_object *object)
-{
-	concurrent_task_continuation *cont;
-
-	cont = (concurrent_task_continuation *) object;
-
-	if (cont->task != NULL) {
-		if (cont->task->fiber.status == CONCURRENT_FIBER_STATUS_SUSPENDED) {
-			concurrent_task_dispose(cont->task);
-		}
-
-		OBJ_RELEASE(&cont->task->fiber.std);
-	}
-
-	zend_object_std_dtor(&cont->std);
-}
-
-ZEND_METHOD(TaskContinuation, __construct)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	zend_throw_error(NULL, "Task continuations must not be constructed from userland code");
-}
-
-ZEND_METHOD(TaskContinuation, __invoke)
-{
-	concurrent_task_continuation *cont;
-	concurrent_task *task;
-
-	zval *error;
-	zval *val;
-
-	cont = (concurrent_task_continuation *) Z_OBJ_P(getThis());
-
-	if (cont->task == NULL) {
-		return;
-	}
-
-	error = NULL;
-	val = NULL;
-
-	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 2)
-		Z_PARAM_ZVAL(error)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_ZVAL(val)
-	ZEND_PARSE_PARAMETERS_END();
-
-	task = cont->task;
-	cont->task = NULL;
-
-	if (error == NULL || Z_TYPE_P(error) == IS_NULL) {
-		if (task->fiber.value != NULL) {
-			ZVAL_COPY(task->fiber.value, val);
-		}
-	} else {
-		ZVAL_COPY(&task->error, error);
-	}
-
-	task->fiber.value = NULL;
-
-	if (task->fiber.status != CONCURRENT_FIBER_STATUS_RUNNING) {
-		concurrent_task_scheduler_enqueue(task);
-	} else {
-		task->operation = CONCURRENT_TASK_OPERATION_RESUME;
-	}
-
-	OBJ_RELEASE(&task->fiber.std);
-}
-
-ZEND_METHOD(TaskContinuation, __wakeup)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	zend_throw_error(NULL, "Unserialization of a task continuation is not allowed");
-}
-
-ZEND_BEGIN_ARG_INFO(arginfo_task_continuation_ctor, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_task_continuation_invoke, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, error, Throwable, 1)
-	ZEND_ARG_INFO(0, value)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_task_continuation_wakeup, 0)
-ZEND_END_ARG_INFO()
-
-static const zend_function_entry task_continuation_functions[] = {
-	ZEND_ME(TaskContinuation, __construct, arginfo_task_continuation_ctor, ZEND_ACC_PRIVATE | ZEND_ACC_CTOR)
-	ZEND_ME(TaskContinuation, __invoke, arginfo_task_continuation_invoke, ZEND_ACC_PUBLIC)
-	ZEND_ME(TaskContinuation, __wakeup, arginfo_task_continuation_wakeup, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -784,16 +454,6 @@ void concurrent_task_ce_register()
 	concurrent_task_handlers.clone_obj = NULL;
 
 	zend_class_implements(concurrent_task_ce, 1, concurrent_awaitable_ce);
-
-	INIT_CLASS_ENTRY(ce, "Concurrent\\TaskContinuation", task_continuation_functions);
-	concurrent_task_continuation_ce = zend_register_internal_class(&ce);
-	concurrent_task_continuation_ce->ce_flags |= ZEND_ACC_FINAL;
-	concurrent_task_continuation_ce->serialize = zend_class_serialize_deny;
-	concurrent_task_continuation_ce->unserialize = zend_class_unserialize_deny;
-
-	memcpy(&concurrent_task_continuation_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	concurrent_task_continuation_handlers.free_obj = concurrent_task_continuation_object_destroy;
-	concurrent_task_continuation_handlers.clone_obj = NULL;
 }
 
 


### PR DESCRIPTION
Re-implementation of continuations without registration of callbacks using the `Awaitable` interface. This solves the problems related to error handling with callback functions. The combinator feature related to `Deferred` (as suggested in #2 ) is missing for now.