### PR TITLE
Improved Scheduling API

### DIFF
--- a/examples/a.php
+++ b/examples/a.php
@@ -6,7 +6,7 @@ use Concurrent\TaskScheduler;
 
 $scheduler = new TaskScheduler();
 
-$scheduler->task(function (): int {
+$result = $scheduler->run(function () {
     $t = Task::async(function (): int {
         return max(123, Task::await(Deferred::value()));
     });
@@ -18,6 +18,8 @@ $scheduler->task(function (): int {
     }
     
     var_dump(2 * Task::await($t));
+    
+    return 777;
 });
 
-$scheduler->run();
+var_dump($result);

--- a/examples/b.php
+++ b/examples/b.php
@@ -7,24 +7,42 @@ use Concurrent\TaskScheduler;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-// Event loop and promise API integration using a scheduler activator.
+// Event loop integration using a customized scheduler.
 
 $loop = \React\EventLoop\Factory::create();
 
-$scheduler = new TaskScheduler(function (TaskScheduler $scheduler) use ($loop) {
-    var_dump('=> RUN');
-    
-    $loop->futureTick([
-        $scheduler,
-        'run'
-    ]);
-});
+$scheduler = new class($loop) extends TaskScheduler {
+
+    protected $loop;
+
+    public function __construct(\React\EventLoop\LoopInterface $loop)
+    {
+        $this->loop = $loop;
+    }
+
+    protected function activate()
+    {
+        var_dump('=> activate');
+        
+        $this->loop->futureTick(\Closure::fromCallable([
+            $this,
+            'dispatch'
+        ]));
+    }
+
+    protected function runLoop()
+    {
+        var_dump('START LOOP');
+        $this->loop->run();
+        var_dump('END LOOP');
+    }
+};
 
 function adapt(\React\Promise\PromiseInterface $promise): Awaitable
 {
     $defer = new Deferred();
     
-    $val->done(function ($v) use ($defer) {
+    $promise->done(function ($v) use ($defer) {
         $defer->resolve($v);
     }, function ($e) use ($defer) {
         $defer->fail(($e instanceof \Throwable) ? $e : new \Error((string) $e));
@@ -33,51 +51,51 @@ function adapt(\React\Promise\PromiseInterface $promise): Awaitable
     return $defer->awaitable();
 }
 
-$defer = new \React\Promise\Deferred();
-
-$work = function (string $title): void {
-    var_dump($title);
-};
-
-$scheduler->task($work, ['A']);
-$scheduler->task($work, ['B']);
-
-$scheduler->task(function () use ($loop) {
-    $defer = new Deferred();
+$scheduler->run(function (\React\EventLoop\LoopInterface $loop) {
+    $defer = new \React\Promise\Deferred();
     
-    $loop->addTimer(.8, function () use ($defer) {
-        $defer->resolve('H :)');
+    $work = function (string $title): void {
+        var_dump($title);
+    };
+    
+    Task::async($work, ['A']);
+    Task::async($work, ['B']);
+    
+    Task::async(function () use ($loop) {
+        $defer = new Deferred();
+        
+        $loop->addTimer(.8, function () use ($defer) {
+            $defer->resolve('H :)');
+        });
+            
+        var_dump(Task::await($defer->awaitable()));
     });
-    
-    var_dump(Task::await($defer->awaitable()));
-});
-
-$scheduler->task(function () use ($defer) {
-    var_dump(Task::await(adapt($defer->promise())));
-});
-
-$loop->addTimer(.05, function () use ($scheduler, $work, $defer) {
-    $defer->resolve('F');
-    
-    $scheduler->task($work, ['G']);
-});
-
-$loop->futureTick(function () use ($loop, $scheduler, $work) {
-    $scheduler->task($work, [
-        'C'
-    ]);
-    
-    $loop->futureTick(function () use ($scheduler, $work) {
-        $scheduler->task($work, [
-            'E'
+        
+    Task::async(function () use ($defer) {
+        var_dump(Task::await(adapt($defer->promise())));
+    });
+        
+    $loop->addTimer(.05, function () use ($work, $defer) {
+        $defer->resolve('F');
+        
+        Task::async($work, ['G']);
+    });
+            
+    $loop->futureTick(function () use ($loop, $work) {
+        Task::async($work, [
+            'C'
         ]);
+        
+        $loop->futureTick(function () use ($work) {
+            Task::async($work, [
+                'E'
+            ]);
+        });
+        
+        Task::async(function ($v) {
+            var_dump(Task::await($v));
+        }, ['D']);
     });
-    
-    $scheduler->task(function ($v) {
-        var_dump(Task::await($v));
-    }, ['D']);
-});
+}, [$loop]);
 
-$loop->run();
-
-var_dump('EXIT LOOP');
+var_dump('DONE');

--- a/examples/c.php
+++ b/examples/c.php
@@ -8,7 +8,7 @@ $scheduler = new TaskScheduler(null, [
     'foo' => 'bar'
 ]);
 
-$t = $scheduler->task(function () {
+$scheduler->run(function () {
     $context = Context::inherit()->with('num', 777);
     $context = $context->with('num', 888);
     
@@ -28,5 +28,3 @@ $t = $scheduler->task(function () {
     
     var_dump(Context::var('num'));
 });
-
-$scheduler->run();

--- a/examples/d.php
+++ b/examples/d.php
@@ -15,7 +15,7 @@ function job(Deferred $defer)
     return 123;
 }
 
-$scheduler->task(function () {
+$scheduler->run(function () {
     $context = Context::inherit([
         'number' => 777
     ]);
@@ -29,5 +29,3 @@ $scheduler->task(function () {
     var_dump(Task::await($t));
     var_dump('OUTER DONE!');
 });
-
-$scheduler->run();

--- a/examples/e.php
+++ b/examples/e.php
@@ -1,0 +1,13 @@
+<?php
+
+use Concurrent\Task;
+
+$task = Task::async(function () {
+    var_dump(321);
+    
+    return 777;
+});
+
+var_dump($task);
+
+var_dump(Task::await($task));

--- a/examples/keywords/d.php
+++ b/examples/keywords/d.php
@@ -15,7 +15,7 @@ function job(Deferred $defer)
     return 123;
 }
 
-$scheduler->task(function () {    
+$scheduler->run(function () {    
     $context = Context::inherit([
         'number' => 777
     ]);
@@ -29,5 +29,3 @@ $scheduler->task(function () {
     var_dump(await $t);
     var_dump('OUTER DONE!');
 });
-
-$scheduler->run();

--- a/examples/stub.php
+++ b/examples/stub.php
@@ -49,15 +49,19 @@ final class Task implements Awaitable
     public static function await($a) { }
 }
 
-final class TaskScheduler implements \Countable
+class TaskScheduler implements \Countable
 {
-    public function __construct(?callable $activator = null, ?array $context = null) { }
-
-    public function count(): int { }
+    public final function count(): int { }
     
-    public function task(callable $callback, ?array $args = null): Task { }
+    public final function run(callable $callback, ?array $args = null) { }
     
-    public function run(): void { }
+    public final function runWithContext(Context $context, callable $callback, ?array $args = null) { }
+    
+    protected final function dispatch(): void { }
+    
+    protected function activate() { }
+    
+    protected function runLoop() { }
 }
 
 final class Fiber

--- a/include/context.h
+++ b/include/context.h
@@ -21,8 +21,6 @@
 
 #include "php.h"
 
-typedef struct _concurrent_task_scheduler concurrent_task_scheduler;
-
 BEGIN_EXTERN_C()
 
 extern zend_class_entry *concurrent_context_ce;
@@ -33,8 +31,6 @@ struct _concurrent_context {
 	zend_object std;
 
 	concurrent_context *parent;
-
-	concurrent_task_scheduler *scheduler;
 
 	uint32_t param_count;
 
@@ -49,7 +45,10 @@ struct _concurrent_context {
 
 concurrent_context *concurrent_context_object_create(HashTable *params);
 
+concurrent_context *concurrent_context_get();
+
 void concurrent_context_ce_register();
+void concurrent_context_shutdown();
 
 END_EXTERN_C()
 

--- a/include/task.h
+++ b/include/task.h
@@ -36,6 +36,9 @@ struct _concurrent_task {
 	/* Embedded fiber. */
 	concurrent_fiber fiber;
 
+	/* Task scheduler being used to execute the task. */
+	concurrent_task_scheduler *scheduler;
+
 	/* Unique identifier of this task. */
 	size_t id;
 

--- a/include/task_scheduler.h
+++ b/include/task_scheduler.h
@@ -43,19 +43,18 @@ struct _concurrent_task_scheduler {
 	/* Points to the last task to be run (needed to insert tasks into the run queue. */
 	concurrent_task *last;
 
-	concurrent_context *context;
-
 	zend_bool running;
 	zend_bool activate;
-
-	zend_bool activator;
-	zend_fcall_info activator_fci;
-	zend_fcall_info_cache activator_fcc;
 };
+
+concurrent_task_scheduler *concurrent_task_scheduler_get();
 
 zend_bool concurrent_task_scheduler_enqueue(concurrent_task *task);
 
+void concurrent_task_scheduler_run(concurrent_task_scheduler *scheduler);
+
 void concurrent_task_scheduler_ce_register();
+void concurrent_task_scheduler_shutdown();
 
 END_EXTERN_C()
 

--- a/php_task.c
+++ b/php_task.c
@@ -98,6 +98,8 @@ static PHP_RINIT_FUNCTION(task)
 
 static PHP_RSHUTDOWN_FUNCTION(task)
 {
+	concurrent_task_scheduler_shutdown();
+	concurrent_context_shutdown();
 	concurrent_fiber_shutdown();
 
 	return SUCCESS;

--- a/php_task.h
+++ b/php_task.h
@@ -51,8 +51,17 @@ ZEND_BEGIN_MODULE_GLOBALS(task)
 	/* Active fiber, NULL when in main thread. */
 	concurrent_fiber *current_fiber;
 
+	/* Root context. */
+	concurrent_context *context;
+
 	/* Active task context. */
 	concurrent_context *current_context;
+
+	/* Default shared task scheduler. */
+	concurrent_task_scheduler *scheduler;
+
+	/* Running task scheduler. */
+	concurrent_task_scheduler *current_scheduler;
 
 	/* Default fiber C stack size. */
 	zend_long stack_size;

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -32,6 +32,35 @@ zend_class_entry *concurrent_task_scheduler_ce;
 static zend_object_handlers concurrent_task_scheduler_handlers;
 
 
+concurrent_task_scheduler *concurrent_task_scheduler_get()
+{
+	concurrent_task_scheduler *scheduler;
+
+	scheduler = TASK_G(current_scheduler);
+
+	if (scheduler != NULL) {
+		return scheduler;
+	}
+
+	scheduler = TASK_G(scheduler);
+
+	if (scheduler != NULL) {
+		return scheduler;
+	}
+
+	scheduler = emalloc(sizeof(concurrent_task_scheduler));
+	ZEND_SECURE_ZERO(scheduler, sizeof(concurrent_task_scheduler));
+
+	zend_object_std_init(&scheduler->std, concurrent_task_scheduler_ce);
+	scheduler->std.handlers = &concurrent_task_scheduler_handlers;
+
+	GC_ADDREF(&scheduler->std);
+
+	TASK_G(scheduler) = scheduler;
+
+	return scheduler;
+}
+
 zend_bool concurrent_task_scheduler_enqueue(concurrent_task *task)
 {
 	concurrent_task_scheduler *scheduler;
@@ -39,11 +68,9 @@ zend_bool concurrent_task_scheduler_enqueue(concurrent_task *task)
 	zval obj;
 	zval retval;
 
-	scheduler = task->context->scheduler;
+	scheduler = task->scheduler;
 
-	if (UNEXPECTED(scheduler == NULL)) {
-		return 0;
-	}
+	ZEND_ASSERT(scheduler != NULL);
 
 	if (task->fiber.status == CONCURRENT_FIBER_STATUS_INIT) {
 		task->operation = CONCURRENT_TASK_OPERATION_START;
@@ -65,163 +92,25 @@ zend_bool concurrent_task_scheduler_enqueue(concurrent_task *task)
 
 	scheduler->scheduled++;
 
-	if (scheduler->activator && scheduler->activate && !scheduler->running) {
+	if (scheduler->activate && !scheduler->running) {
 		scheduler->activate = 0;
 
 		ZVAL_OBJ(&obj, &scheduler->std);
 
-		scheduler->activator_fci.param_count = 1;
-		scheduler->activator_fci.params = &obj;
-		scheduler->activator_fci.retval = &retval;
+		zend_string *name = zend_string_init("activate", sizeof("activate")-1, 0);
+		zval *entry = zend_hash_find_ex(&scheduler->std.ce->function_table, name, 0);
+		zend_function *func = Z_FUNC_P(entry);
 
-		zend_call_function(&scheduler->activator_fci, &scheduler->activator_fcc);
+		zend_call_method_with_0_params(&obj, Z_OBJCE_P(&obj), &func, "activate", &retval);
 		zval_ptr_dtor(&retval);
 	}
 
 	return 1;
 }
 
-
-static zend_object *concurrent_task_scheduler_object_create(zend_class_entry *ce)
+void concurrent_task_scheduler_run(concurrent_task_scheduler *scheduler)
 {
-	concurrent_task_scheduler *scheduler;
-
-	scheduler = emalloc(sizeof(concurrent_task_scheduler));
-	ZEND_SECURE_ZERO(scheduler, sizeof(concurrent_task_scheduler));
-
-	scheduler->activate = 1;
-
-	zend_object_std_init(&scheduler->std, ce);
-	scheduler->std.handlers = &concurrent_task_scheduler_handlers;
-
-	return &scheduler->std;
-}
-
-static void concurrent_task_scheduler_object_destroy(zend_object *object)
-{
-	concurrent_task_scheduler *scheduler;
 	concurrent_task *task;
-
-	scheduler = (concurrent_task_scheduler *) object;
-
-	while (scheduler->first != NULL) {
-		task = scheduler->first;
-
-		scheduler->scheduled--;
-		scheduler->first = task->next;
-
-		OBJ_RELEASE(&task->fiber.std);
-	}
-
-	if (scheduler->activator) {
-		scheduler->activator = 0;
-
-		zval_ptr_dtor(&scheduler->activator_fci.function_name);
-	}
-
-	OBJ_RELEASE(&scheduler->context->std);
-
-	zend_object_std_dtor(&scheduler->std);
-}
-
-ZEND_METHOD(TaskScheduler, __construct)
-{
-	concurrent_task_scheduler *scheduler;
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcc;
-
-	zval *params;
-	HashTable *table;
-
-	scheduler = (concurrent_task_scheduler *)Z_OBJ_P(getThis());
-
-	fci = empty_fcall_info;
-	fcc = empty_fcall_info_cache;
-
-	params = NULL;
-	table = NULL;
-
-	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 2)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_FUNC_EX(fci, fcc, 1, 0)
-		Z_PARAM_ZVAL(params)
-	ZEND_PARSE_PARAMETERS_END();
-
-	if (Z_TYPE_P(&fci.function_name) != IS_UNDEF) {
-		scheduler->activator = 1;
-		scheduler->activator_fci = fci;
-		scheduler->activator_fcc = fcc;
-
-		Z_TRY_ADDREF_P(&fci.function_name);
-	}
-
-	if (params != NULL && Z_TYPE_P(params) == IS_ARRAY) {
-		table = Z_ARRVAL_P(params);
-	}
-
-	scheduler->context = concurrent_context_object_create(table);
-	scheduler->context->scheduler = scheduler;
-}
-
-ZEND_METHOD(TaskScheduler, count)
-{
-	concurrent_task_scheduler *scheduler;
-
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	scheduler = (concurrent_task_scheduler *)Z_OBJ_P(getThis());
-
-	RETURN_LONG(scheduler->scheduled);
-}
-
-ZEND_METHOD(TaskScheduler, task)
-{
-	concurrent_task_scheduler *scheduler;
-	concurrent_task * task;
-
-	zval *params;
-	zval obj;
-
-	scheduler = (concurrent_task_scheduler *) Z_OBJ_P(getThis());
-
-	task = concurrent_task_object_create();
-	task->context = scheduler->context;
-
-	params = NULL;
-
-	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 2)
-		Z_PARAM_FUNC_EX(task->fiber.fci, task->fiber.fcc, 1, 0)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_ARRAY(params)
-	ZEND_PARSE_PARAMETERS_END();
-
-	task->fiber.fci.no_separation = 1;
-
-	if (params == NULL) {
-		task->fiber.fci.param_count = 0;
-	} else {
-		zend_fcall_info_args(&task->fiber.fci, params);
-	}
-
-	Z_TRY_ADDREF_P(&task->fiber.fci.function_name);
-
-	GC_ADDREF(&task->context->std);
-
-	concurrent_task_scheduler_enqueue(task);
-
-	ZVAL_OBJ(&obj, &task->fiber.std);
-
-	RETURN_ZVAL(&obj, 1, 1);
-}
-
-ZEND_METHOD(TaskScheduler, run)
-{
-	concurrent_task_scheduler *scheduler;
-	concurrent_task *task;
-
-	scheduler = (concurrent_task_scheduler *) Z_OBJ_P(getThis());
-
-	ZEND_PARSE_PARAMETERS_NONE();
 
 	scheduler->running = 1;
 	scheduler->activate = 0;
@@ -269,6 +158,230 @@ ZEND_METHOD(TaskScheduler, run)
 	scheduler->activate = 1;
 }
 
+
+static zend_object *concurrent_task_scheduler_object_create(zend_class_entry *ce)
+{
+	concurrent_task_scheduler *scheduler;
+
+	scheduler = emalloc(sizeof(concurrent_task_scheduler));
+	ZEND_SECURE_ZERO(scheduler, sizeof(concurrent_task_scheduler));
+
+	scheduler->activate = 1;
+
+	zend_object_std_init(&scheduler->std, ce);
+	scheduler->std.handlers = &concurrent_task_scheduler_handlers;
+
+	return &scheduler->std;
+}
+
+static void concurrent_task_scheduler_object_destroy(zend_object *object)
+{
+	concurrent_task_scheduler *scheduler;
+	concurrent_task *task;
+
+	scheduler = (concurrent_task_scheduler *) object;
+
+	while (scheduler->first != NULL) {
+		task = scheduler->first;
+
+		scheduler->scheduled--;
+		scheduler->first = task->next;
+
+		OBJ_RELEASE(&task->fiber.std);
+	}
+
+	zend_object_std_dtor(&scheduler->std);
+}
+
+ZEND_METHOD(TaskScheduler, count)
+{
+	concurrent_task_scheduler *scheduler;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	scheduler = (concurrent_task_scheduler *)Z_OBJ_P(getThis());
+
+	RETURN_LONG(scheduler->scheduled);
+}
+
+ZEND_METHOD(TaskScheduler, activate)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+}
+
+ZEND_METHOD(TaskScheduler, run)
+{
+	concurrent_task_scheduler *scheduler;
+	concurrent_task_scheduler *prev;
+	concurrent_task *task;
+
+	zval *params;
+	zval obj;
+	zval retval;
+
+	scheduler = (concurrent_task_scheduler *) Z_OBJ_P(getThis());
+
+	task = concurrent_task_object_create();
+	task->scheduler = scheduler;
+	task->context = concurrent_context_get();
+
+	params = NULL;
+
+	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 2)
+		Z_PARAM_FUNC_EX(task->fiber.fci, task->fiber.fcc, 1, 0)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ARRAY(params)
+	ZEND_PARSE_PARAMETERS_END();
+
+	task->fiber.fci.no_separation = 1;
+
+	if (params == NULL) {
+		task->fiber.fci.param_count = 0;
+	} else {
+		zend_fcall_info_args(&task->fiber.fci, params);
+	}
+
+	Z_TRY_ADDREF_P(&task->fiber.fci.function_name);
+
+	GC_ADDREF(&task->context->std);
+
+	concurrent_task_scheduler_enqueue(task);
+
+	prev = TASK_G(current_scheduler);
+	TASK_G(current_scheduler) = scheduler;
+
+	ZVAL_OBJ(&obj, &scheduler->std);
+
+	zend_string *name = zend_string_init("runloop", sizeof("runloop")-1, 0);
+	zval *entry = zend_hash_find_ex(&scheduler->std.ce->function_table, name, 0);
+	zend_function *func = Z_FUNC_P(entry);
+
+	zend_call_method_with_0_params(&obj, Z_OBJCE_P(&obj), &func, "runloop", &retval);
+	zval_ptr_dtor(&retval);
+
+	TASK_G(current_scheduler) = prev;
+
+	if (task->fiber.status == CONCURRENT_FIBER_STATUS_FINISHED) {
+		RETURN_ZVAL(&task->result, 1, 0);
+	}
+
+	if (task->fiber.status == CONCURRENT_FIBER_STATUS_DEAD) {
+		Z_ADDREF_P(&task->result);
+
+		execute_data->opline--;
+		zend_throw_exception_internal(&task->result);
+		execute_data->opline++;
+
+		return;
+	}
+
+	zend_throw_error(NULL, "Scheduled task did not run to completion");
+}
+
+ZEND_METHOD(TaskScheduler, runWithContext)
+{
+	concurrent_task_scheduler *scheduler;
+	concurrent_task_scheduler *prev;
+	concurrent_task *task;
+
+	zval *ctx;
+	zval *params;
+	zval obj;
+	zval retval;
+
+	scheduler = (concurrent_task_scheduler *) Z_OBJ_P(getThis());
+
+	task = concurrent_task_object_create();
+	task->scheduler = scheduler;
+
+	params = NULL;
+
+	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 3)
+		Z_PARAM_ZVAL(ctx)
+		Z_PARAM_FUNC_EX(task->fiber.fci, task->fiber.fcc, 1, 0)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ARRAY(params)
+	ZEND_PARSE_PARAMETERS_END();
+
+	task->context = (concurrent_context *) Z_OBJ_P(ctx);
+	task->fiber.fci.no_separation = 1;
+
+	if (params == NULL) {
+		task->fiber.fci.param_count = 0;
+	} else {
+		zend_fcall_info_args(&task->fiber.fci, params);
+	}
+
+	Z_TRY_ADDREF_P(&task->fiber.fci.function_name);
+
+	GC_ADDREF(&task->context->std);
+
+	concurrent_task_scheduler_enqueue(task);
+
+	prev = TASK_G(current_scheduler);
+	TASK_G(current_scheduler) = scheduler;
+
+	ZVAL_OBJ(&obj, &scheduler->std);
+
+	zend_string *name = zend_string_init("runloop", sizeof("runloop")-1, 0);
+	zval *entry = zend_hash_find_ex(&scheduler->std.ce->function_table, name, 0);
+	zend_function *func = Z_FUNC_P(entry);
+
+	zend_call_method_with_0_params(&obj, Z_OBJCE_P(&obj), &func, "runloop", &retval);
+	zval_ptr_dtor(&retval);
+
+	TASK_G(current_scheduler) = prev;
+
+	if (task->fiber.status == CONCURRENT_FIBER_STATUS_FINISHED) {
+		RETURN_ZVAL(&task->result, 1, 0);
+	}
+
+	if (task->fiber.status == CONCURRENT_FIBER_STATUS_DEAD) {
+		Z_ADDREF_P(&task->result);
+
+		execute_data->opline--;
+		zend_throw_exception_internal(&task->result);
+		execute_data->opline++;
+
+		return;
+	}
+
+	zend_throw_error(NULL, "Scheduled task did not run to completion");
+}
+
+ZEND_METHOD(TaskScheduler, dispatch)
+{
+	concurrent_task_scheduler *scheduler;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	scheduler = (concurrent_task_scheduler *) Z_OBJ_P(getThis());
+
+	if (scheduler->running) {
+		zend_throw_error(NULL, "Cannot dispatch tasks because the dispatcher is already running");
+		return;
+	}
+
+	concurrent_task_scheduler_run(scheduler);
+}
+
+ZEND_METHOD(TaskScheduler, runLoop)
+{
+	concurrent_task_scheduler *scheduler;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	scheduler = (concurrent_task_scheduler *) Z_OBJ_P(getThis());
+
+	if (scheduler->running) {
+		zend_throw_error(NULL, "Cannot dispatch tasks because the dispatcher is already running");
+		return;
+	}
+
+	concurrent_task_scheduler_run(scheduler);
+}
+
+
 ZEND_METHOD(TaskScheduler, __wakeup)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
@@ -276,31 +389,40 @@ ZEND_METHOD(TaskScheduler, __wakeup)
 	zend_throw_error(NULL, "Unserialization of a task scheduler is not allowed");
 }
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_task_scheduler_ctor, 0, 0, 0)
-	ZEND_ARG_CALLABLE_INFO(0, callback, 1)
-	ZEND_ARG_ARRAY_INFO(0, context, 1)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_INFO(arginfo_task_scheduler_count, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_task_scheduler_task, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO(arginfo_task_scheduler_activate, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_task_scheduler_run, 0, 0, 1)
 	ZEND_ARG_CALLABLE_INFO(0, callback, 0)
 	ZEND_ARG_ARRAY_INFO(0, arguments, 1)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_task_scheduler_run, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_task_scheduler_run_with_context, 0, 0, 2)
+	ZEND_ARG_OBJ_INFO(0, context, Concurrent\\Context, 0)
+	ZEND_ARG_CALLABLE_INFO(0, callback, 0)
+	ZEND_ARG_ARRAY_INFO(0, arguments, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_task_scheduler_run_loop, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_task_scheduler_dispatch, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_task_scheduler_wakeup, 0)
 ZEND_END_ARG_INFO()
 
 static const zend_function_entry task_scheduler_functions[] = {
-	ZEND_ME(TaskScheduler, __construct, arginfo_task_scheduler_ctor, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-	ZEND_ME(TaskScheduler, count, arginfo_task_scheduler_count, ZEND_ACC_PUBLIC)
-	ZEND_ME(TaskScheduler, task, arginfo_task_scheduler_task, ZEND_ACC_PUBLIC)
-	ZEND_ME(TaskScheduler, run, arginfo_task_scheduler_run, ZEND_ACC_PUBLIC)
-	ZEND_ME(TaskScheduler, __wakeup, arginfo_task_scheduler_wakeup, ZEND_ACC_PUBLIC)
+	ZEND_ME(TaskScheduler, count, arginfo_task_scheduler_count, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	ZEND_ME(TaskScheduler, activate, arginfo_task_scheduler_activate, ZEND_ACC_PROTECTED)
+	ZEND_ME(TaskScheduler, run, arginfo_task_scheduler_run, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	ZEND_ME(TaskScheduler, runWithContext, arginfo_task_scheduler_run_with_context, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
+	ZEND_ME(TaskScheduler, dispatch, arginfo_task_scheduler_dispatch, ZEND_ACC_PROTECTED | ZEND_ACC_FINAL)
+	ZEND_ME(TaskScheduler, runLoop, arginfo_task_scheduler_run_loop, ZEND_ACC_PROTECTED)
+	ZEND_ME(TaskScheduler, __wakeup, arginfo_task_scheduler_wakeup, ZEND_ACC_PUBLIC | ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -311,7 +433,6 @@ void concurrent_task_scheduler_ce_register()
 
 	INIT_CLASS_ENTRY(ce, "Concurrent\\TaskScheduler", task_scheduler_functions);
 	concurrent_task_scheduler_ce = zend_register_internal_class(&ce);
-	concurrent_task_scheduler_ce->ce_flags |= ZEND_ACC_FINAL;
 	concurrent_task_scheduler_ce->create_object = concurrent_task_scheduler_object_create;
 	concurrent_task_scheduler_ce->serialize = zend_class_serialize_deny;
 	concurrent_task_scheduler_ce->unserialize = zend_class_unserialize_deny;
@@ -321,6 +442,17 @@ void concurrent_task_scheduler_ce_register()
 	memcpy(&concurrent_task_scheduler_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	concurrent_task_scheduler_handlers.free_obj = concurrent_task_scheduler_object_destroy;
 	concurrent_task_scheduler_handlers.clone_obj = NULL;
+}
+
+void concurrent_task_scheduler_shutdown()
+{
+	concurrent_task_scheduler *scheduler;
+
+	scheduler = TASK_G(scheduler);
+
+	if (scheduler != NULL) {
+		concurrent_task_scheduler_object_destroy(&scheduler->std);
+	}
 }
 
 

--- a/tests/100-task-scheduling.phpt
+++ b/tests/100-task-scheduling.phpt
@@ -12,30 +12,27 @@ namespace Concurrent;
 $scheduler = new TaskScheduler();
 var_dump(count($scheduler));
 
-$t1 = $scheduler->task(function () {
-    var_dump('A');
+$result = $scheduler->run(function () use ($scheduler) {
+	var_dump(count($scheduler));
+	
+	$t1 = Task::async('var_dump', ['B']);
+	
+	var_dump(count($scheduler));
+	
+	var_dump('A');
+	
+	return 'C';
 });
 
-$scheduler->task(function () use ($scheduler) {
-    $scheduler->task(function () {
-        var_dump('C');
-    });
-
-    var_dump('B');
-});
-
-var_dump($t1 instanceof Task);
-var_dump(count($scheduler));
-
-$scheduler->run();
+var_dump($result);
 
 var_dump(count($scheduler));
 
 ?>
 --EXPECT--
 int(0)
-bool(true)
-int(2)
+int(0)
+int(1)
 string(1) "A"
 string(1) "B"
 string(1) "C"

--- a/tests/101-static-task-scheduling.phpt
+++ b/tests/101-static-task-scheduling.phpt
@@ -11,7 +11,9 @@ namespace Concurrent;
 
 $scheduler = new TaskScheduler();
 
-$scheduler->task(function () {
+var_dump(count($scheduler));
+
+$scheduler->run(function () {
     $t = Task::async(function (string $title) {
         var_dump($title);
     }, ['A']);
@@ -31,13 +33,9 @@ $scheduler->task(function () {
 
 var_dump(count($scheduler));
 
-$scheduler->run();
-
-var_dump(count($scheduler));
-
 ?>
 --EXPECT--
-int(1)
+int(0)
 bool(true)
 string(1) "A"
 string(1) "B"

--- a/tests/102-task-await.phpt
+++ b/tests/102-task-await.phpt
@@ -11,7 +11,7 @@ namespace Concurrent;
 
 $scheduler = new TaskScheduler();
 
-$scheduler->task(function () {
+$scheduler->run(function () {
     var_dump('A');
     
     var_dump(Task::await('B'));
@@ -31,8 +31,6 @@ $scheduler->task(function () {
     
     var_dump(Task::await($t));
 });
-
-$scheduler->run();
 
 ?>
 --EXPECT--

--- a/tests/104-task-default-scheduler.phpt
+++ b/tests/104-task-default-scheduler.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Task will be run on a default scheduler.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+$work = function (string $a) {
+    return $a;
+};
+
+var_dump(Task::await(Task::async($work, ['A'])));
+var_dump(Task::await(Task::async($work, ['B'])));
+
+$t = Task::async(function () {
+    $defer = new Deferred();
+    
+    Task::async(function () use ($defer) {
+        $defer->resolve('C');
+    });
+    
+    return Task::await($defer->awaitable());
+});
+
+var_dump(Task::await($t));
+
+$t = Task::async(function () {
+    $defer = new Deferred();
+    
+    Task::async(function () use ($defer) {
+        $defer->fail(new \Error('D'));
+    });
+    
+    return Task::await($defer->awaitable());
+});
+
+try {
+    Task::await($t);
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
+
+?>
+--EXPECT--
+string(1) "A"
+string(1) "B"
+string(1) "C"
+string(1) "D"

--- a/tests/105-task-activator.phpt
+++ b/tests/105-task-activator.phpt
@@ -9,26 +9,30 @@ if (!extension_loaded('task')) echo 'Test requires the task extension to be load
 
 namespace Concurrent;
 
-$scheduler = new TaskScheduler(function () {
-    var_dump('ACTIVATE!');
-});
+$scheduler = new class() extends TaskScheduler
+{
+    protected function activate()
+    {
+        var_dump('ACTIVATE!');
+    }
+};
 
 $work = function (string $v): void {
     var_dump($v);
 };
 
-$scheduler->task($work, ['A']);
-$scheduler->run();
+$scheduler->run($work, ['A']);
 
-$scheduler->task($work, ['B']);
-$scheduler->task($work, ['C']);
-$scheduler->run();
+$scheduler->run(function () use ($work) {
+    $work('B');
+    
+    Task::async($work, ['C']);
+});
 
-$scheduler->task($work, ['D']);
-$scheduler->task(function () use ($work) {
+$scheduler->run(function () use ($work) {
+    Task::async($work, ['D']);
     Task::async($work, ['E']);
 });
-$scheduler->run();
 
 ?>
 --EXPECT--

--- a/tests/107-task-error-continue.phpt
+++ b/tests/107-task-error-continue.phpt
@@ -11,31 +11,23 @@ namespace Concurrent;
 
 $scheduler = new TaskScheduler();
 
-$t = $scheduler->task(function () {
-    throw new \Error('Fail 1');
-});
-
-$scheduler->run();
-
-$scheduler->task(function () use ($t) {
-    try {
-        Task::await($t);
-    } catch (\Throwable $e) {
-        var_dump($e->getMessage());
-    }
-});
-
-$t = $scheduler->task(function () {
+$scheduler->run(function () {
     try {
         Task::await(Task::async(function () {
-            throw new \Error('Fail 2');
+            throw new \Error('Fail 1');
         }));
     } catch (\Throwable $e) {
         var_dump($e->getMessage());
     }
 });
 
-$scheduler->run();
+try {
+    $scheduler->run(function () {
+        throw new \Error('Fail 2');
+    });
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
 
 ?>
 --EXPECT--

--- a/tests/108-task-multiple-continuations.phpt
+++ b/tests/108-task-multiple-continuations.phpt
@@ -11,7 +11,7 @@ namespace Concurrent;
 
 $scheduler = new TaskScheduler();
 
-$scheduler->task(function () {
+$scheduler->run(function () {
     $t = Task::async(function () {
         return 123;
     });
@@ -29,9 +29,7 @@ $scheduler->task(function () {
     var_dump(Task::await($t));
 });
 
-$scheduler->run();
-
-$scheduler->task(function () {
+$scheduler->run(function () {
     $t = null;
 
     $a = Task::async(function () use (& $t) {
@@ -50,8 +48,6 @@ $scheduler->task(function () {
     var_dump(Task::await($b));
     var_dump(Task::await($t));
 });
-
-$scheduler->run();
 
 ?>
 --EXPECT--

--- a/tests/110-task-is-running.phpt
+++ b/tests/110-task-is-running.phpt
@@ -15,13 +15,11 @@ $f = new Fiber(function () {
     var_dump(Fiber::isRunning(), Task::isRunning());
 });
 
-$scheduler->task(function () {
-    var_dump(Fiber::isRunning(), Task::isRunning());
-});
-
 var_dump(Task::isRunning());
 
-$scheduler->run();
+$scheduler->run(function () {
+    var_dump(Fiber::isRunning(), Task::isRunning());
+});
 
 var_dump(Task::isRunning());
 

--- a/tests/111-task-inlining.phpt
+++ b/tests/111-task-inlining.phpt
@@ -13,31 +13,33 @@ $scheduler = new TaskScheduler(null, [
     'num' => 123
 ]);
 
-$scheduler->task(function () {
-    $callback = function () {
-        return Context::var('num');
-    };
-
-    var_dump($callback());
-    
-    var_dump(Task::await(Task::async($callback)));
-
-    var_dump($callback());
-    
-    var_dump(Task::await(Task::asyncWithContext(Context::inherit(['num' => 777]), $callback)));
-
-    var_dump($callback());
-    
-    try {
-        Task::await(Task::async(function () {
-            throw new \Error('FAIL!');
-        }));
-    } catch (\Throwable $e) {
-        var_dump($e->getMessage());
-    }
+$scheduler->run(function () {
+    Task::asyncWithContext(Context::inherit([
+        'num' => 123
+    ]), function () {
+	    $callback = function () {
+	        return Context::var('num');
+	    };
+	
+	    var_dump($callback());
+	    
+	    var_dump(Task::await(Task::async($callback)));
+	
+	    var_dump($callback());
+	    
+	    var_dump(Task::await(Task::asyncWithContext(Context::inherit(['num' => 777]), $callback)));
+	
+	    var_dump($callback());
+	    
+	    try {
+	        Task::await(Task::async(function () {
+	            throw new \Error('FAIL!');
+	        }));
+	    } catch (\Throwable $e) {
+	        var_dump($e->getMessage());
+	    }
+    });
 });
-
-$scheduler->run();
 
 ?>
 --EXPECT--

--- a/tests/200-context-var-access.phpt
+++ b/tests/200-context-var-access.phpt
@@ -11,7 +11,9 @@ namespace Concurrent;
 
 $scheduler = new TaskScheduler();
 
-$scheduler->task(function () {
+var_dump(Context::var('foo'));
+
+$scheduler->run(function () {
     var_dump(Context::var('foo'));
     
     Task::asyncWithContext(Context::inherit([
@@ -33,19 +35,11 @@ $scheduler->task(function () {
     });
 });
 
-var_dump(Context::var('foo'));
-
-$scheduler->run();
-
-$scheduler = new TaskScheduler(null, [
+$scheduler->runWithContext(Context::inherit([
     'foo' => 'bar'
-]);
-
-$scheduler->task(function () {
+]), function () {
     var_dump(Context::var('foo'));
 });
-
-$scheduler->run();
 
 ?>
 --EXPECT--

--- a/tests/207-context-current.phpt
+++ b/tests/207-context-current.phpt
@@ -11,7 +11,7 @@ namespace Concurrent;
 
 $scheduler = new TaskScheduler();
 
-$scheduler->task(function () {
+$scheduler->run(function () {
 	$context = Context::current();
 	var_dump($context instanceof Context);
 	
@@ -29,8 +29,6 @@ $scheduler->task(function () {
 	
 	var_dump($context === Context::current());
 });
-
-$scheduler->run();
 
 ?>
 --EXPECT--


### PR DESCRIPTION
Introduced a default root context and task scheduler that are always available. Changed the `TaskScheduler` API to always enter async execution with a "master task" that is passed as callback to the run method. The `task()` method has been removed from the scheduler as suggested in #10. The idle task problem described in #15 is not fully solved yet.

There is no way to set the default task scheduler yet, i will implement this in another commit.