### PR TITLE
Support for Awaitable Combinators

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ final class Deferred
     public static function value($val = null): Awaitable { }
     
     public static function error(\Throwable $e): Awaitable { }
+    
+    public static function combine(array $awaitables, callable $continuation): Awaitable { }
 }
 ```
 

--- a/examples/combinators.php
+++ b/examples/combinators.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Concurrent;
+
+$scheduler = new TaskScheduler();
+
+function all(array $awaitables): Awaitable
+{
+    if (empty($awaitables)) {
+        return Deferred::value([]);
+    }
+    
+    foreach ($awaitables as $a) {
+        if (!$a instanceof Awaitable) {
+            throw new \InvalidArgumentException('All awaited items must be awaitables');
+        }
+    }
+    
+    $defer = new Deferred();
+    
+    $result = \array_fill_keys(\array_keys($awaitables), null);
+    $remaining = \count($awaitables);
+    
+    foreach ($awaitables as $k => $a) {
+        Task::async(function () use ($k, $a, $defer, & $result, & $remaining) {
+            try {
+                $result[$k] = Task::await($a);
+                
+                if (--$remaining === 0) {
+                    $defer->resolve($result);
+                }
+            } catch (\Throwable $e) {
+                $defer->fail($e);
+            }
+        });
+    }
+    
+    return $defer->awaitable();
+}
+
+function all2(array $awaitables): Awaitable
+{
+    if (empty($awaitables)) {
+        return Deferred::value([]);
+    }
+    
+    $result = \array_fill_keys(\array_keys($awaitables), null);
+    $remaining = \count($awaitables);
+    
+    return Deferred::combine($awaitables, function (Deferred $defer, $k, ?\Throwable $e, $v = null) use (& $result, & $remaining) {
+        if ($e) {
+            $defer->fail($e);
+        } else {
+            $result[$k] = $v;
+            
+            if (--$remaining === 0) {
+                $defer->resolve($result);
+            }
+        }
+    });
+}
+
+function race(array $awaitables): Awaitable
+{
+    if (empty($awaitables)) {
+        throw new \InvalidArgumentException('At least one awaitable is required');
+    }
+    
+    foreach ($awaitables as $a) {
+        if (!$a instanceof Awaitable) {
+            throw new \InvalidArgumentException('All awaited items must be awaitables');
+        }
+    }
+    
+    $defer = new Deferred();
+    
+    foreach ($awaitables as $a) {
+        Task::async(function () use ($a, $defer) {
+            $defer->resolve(Task::await($a));
+        });
+    }
+    
+    return $defer->awaitable();
+}
+
+function any(array $awaitables): Awaitable
+{
+    if (empty($awaitables)) {
+        throw new \InvalidArgumentException('At least one awaitable is required');
+    }
+    
+    foreach ($awaitables as $a) {
+        if (!$a instanceof Awaitable) {
+            throw new \InvalidArgumentException('All awaited items must be awaitables');
+        }
+    }
+    
+    $defer = new Deferred();
+    
+    foreach ($awaitables as $a) {
+        Task::async(function () use ($a, $defer) {
+            try {
+                $defer->resolve(Task::await($a));
+            } catch (\Throwable $e) {
+                $defer->fail($e);
+            }
+        });
+    }
+    
+    return $defer->awaitable();
+}
+
+$result = $scheduler->run(function () {
+    $t = Task::async(function () {
+        return 321;
+    });
+    
+    return Task::await(all2([
+        'A' => $t,
+        'B' => Deferred::value(777)
+    ]));
+});
+
+var_dump($result);

--- a/examples/combinators.php
+++ b/examples/combinators.php
@@ -45,19 +45,20 @@ function all2(array $awaitables): Awaitable
     }
     
     $result = \array_fill_keys(\array_keys($awaitables), null);
-    $remaining = \count($awaitables);
     
-    return Deferred::combine($awaitables, function (Deferred $defer, $k, ?\Throwable $e, $v = null) use (& $result, & $remaining) {
+    $all = function (Deferred $defer, $last, $k, $e, $v) use (& $result) {
         if ($e) {
             $defer->fail($e);
         } else {
             $result[$k] = $v;
             
-            if (--$remaining === 0) {
+            if ($last) {
                 $defer->resolve($result);
             }
         }
-    });
+    };
+    
+    return Deferred::combine($awaitables, $all);
 }
 
 function race(array $awaitables): Awaitable

--- a/examples/stub.php
+++ b/examples/stub.php
@@ -34,6 +34,8 @@ final class Deferred
     public static function value($val = null): Awaitable { }
     
     public static function error(\Throwable $e): Awaitable { }
+    
+    public static function combine(array $awaitables, callable $continuation): Awaitable { }
 }
 
 final class DeferredAwaitable implements Awaitable { }

--- a/include/awaitable.h
+++ b/include/awaitable.h
@@ -27,16 +27,17 @@ extern zend_class_entry *concurrent_awaitable_ce;
 
 typedef struct _concurrent_awaitable_cb concurrent_awaitable_cb;
 
-typedef void (* concurrent_awaitable_func)(void *obj, zval *result, zend_bool success);
+typedef void (*concurrent_awaitable_func)(void *obj, zval *data, zval *result, zend_bool success);
 
 struct _concurrent_awaitable_cb {
 	void *object;
+	zval data;
 	concurrent_awaitable_func func;
 	concurrent_awaitable_cb *next;
 };
 
-concurrent_awaitable_cb *concurrent_awaitable_create_continuation(void *obj, concurrent_awaitable_func func);
-void concurrent_awaitable_append_continuation(concurrent_awaitable_cb *prev, void *obj, concurrent_awaitable_func func);
+concurrent_awaitable_cb *concurrent_awaitable_create_continuation(void *obj, zval *data, concurrent_awaitable_func func);
+void concurrent_awaitable_append_continuation(concurrent_awaitable_cb *prev, void *obj, zval *data, concurrent_awaitable_func func);
 
 void concurrent_awaitable_trigger_continuation(concurrent_awaitable_cb **cont, zval *result, zend_bool success);
 void concurrent_awaitable_dispose_continuation(concurrent_awaitable_cb **cont);

--- a/include/task_scheduler.h
+++ b/include/task_scheduler.h
@@ -54,6 +54,8 @@ zend_bool concurrent_task_scheduler_enqueue(concurrent_task *task);
 void concurrent_task_scheduler_run_loop(concurrent_task_scheduler *scheduler);
 
 void concurrent_task_scheduler_ce_register();
+void concurrent_task_scheduler_ce_unregister();
+
 void concurrent_task_scheduler_shutdown();
 
 END_EXTERN_C()

--- a/php_task.c
+++ b/php_task.c
@@ -69,6 +69,7 @@ PHP_MINIT_FUNCTION(task)
 
 PHP_MSHUTDOWN_FUNCTION(task)
 {
+	concurrent_task_scheduler_ce_unregister();
 	concurrent_fiber_ce_unregister();
 
 	UNREGISTER_INI_ENTRIES();

--- a/src/awaitable.c
+++ b/src/awaitable.c
@@ -95,10 +95,8 @@ void concurrent_awaitable_dispose_continuation(concurrent_awaitable_cb **cont)
 	current = *cont;
 
 	if (current != NULL) {
-		zend_throw_error(NULL, "Awaitable has been disposed before it was resolved");
-
-		ZVAL_OBJ(&error, EG(exception));
-		EG(exception) = NULL;
+		// FIXME: Create a proper error to be forwared into tasks.
+		ZVAL_NULL(&error);
 
 		do {
 			next = current->next;

--- a/src/awaitable.c
+++ b/src/awaitable.c
@@ -96,7 +96,9 @@ void concurrent_awaitable_dispose_continuation(concurrent_awaitable_cb **cont)
 
 	if (current != NULL) {
 		zend_throw_error(NULL, "Awaitable has been disposed before it was resolved");
+
 		ZVAL_OBJ(&error, EG(exception));
+		EG(exception) = NULL;
 
 		do {
 			next = current->next;

--- a/src/awaitable.c
+++ b/src/awaitable.c
@@ -21,7 +21,7 @@
 zend_class_entry *concurrent_awaitable_ce;
 
 
-concurrent_awaitable_cb *concurrent_awaitable_create_continuation(void *obj, concurrent_awaitable_func func)
+concurrent_awaitable_cb *concurrent_awaitable_create_continuation(void *obj, zval *data, concurrent_awaitable_func func)
 {
 	concurrent_awaitable_cb *cont;
 
@@ -31,10 +31,16 @@ concurrent_awaitable_cb *concurrent_awaitable_create_continuation(void *obj, con
 	cont->func = func;
 	cont->next = NULL;
 
+	if (data == NULL) {
+		ZVAL_UNDEF(&cont->data);
+	} else {
+		ZVAL_COPY(&cont->data, data);
+	}
+
 	return cont;
 }
 
-void concurrent_awaitable_append_continuation(concurrent_awaitable_cb *prev, void *obj, concurrent_awaitable_func func)
+void concurrent_awaitable_append_continuation(concurrent_awaitable_cb *prev, void *obj, zval *data, concurrent_awaitable_func func)
 {
 	concurrent_awaitable_cb *cont;
 
@@ -45,6 +51,12 @@ void concurrent_awaitable_append_continuation(concurrent_awaitable_cb *prev, voi
 	cont->object = obj;
 	cont->func = func;
 	cont->next = NULL;
+
+	if (data == NULL) {
+		ZVAL_UNDEF(&cont->data);
+	} else {
+		ZVAL_COPY(&cont->data, data);
+	}
 
 	prev->next = cont;
 }
@@ -61,7 +73,9 @@ void concurrent_awaitable_trigger_continuation(concurrent_awaitable_cb **cont, z
 			next = current->next;
 			*cont = next;
 
-			current->func(current->object, result, success);
+			current->func(current->object, &current->data, result, success);
+
+			zval_ptr_dtor(&current->data);
 
 			efree(current);
 
@@ -88,7 +102,9 @@ void concurrent_awaitable_dispose_continuation(concurrent_awaitable_cb **cont)
 			next = current->next;
 			*cont = next;
 
-			current->func(current->object, &error, 0);
+			current->func(current->object, &current->data, &error, 0);
+
+			zval_ptr_dtor(&current->data);
 
 			efree(current);
 

--- a/src/context.c
+++ b/src/context.c
@@ -53,8 +53,6 @@ concurrent_context *concurrent_context_get()
 	zend_object_std_init(&context->std, concurrent_context_ce);
 	context->std.handlers = &concurrent_context_handlers;
 
-	GC_ADDREF(&context->std);
-
 	TASK_G(context) = context;
 
 	return context;
@@ -75,8 +73,6 @@ concurrent_context *concurrent_context_object_create(HashTable *params)
 
 	zend_object_std_init(&context->std, concurrent_context_ce);
 	context->std.handlers = &concurrent_context_handlers;
-
-	GC_ADDREF(&context->std);
 
 	if (params != NULL) {
 		context->param_count = zend_hash_num_elements(params);
@@ -104,8 +100,6 @@ static concurrent_context *concurrent_context_object_create_single_var(zend_stri
 
 	zend_object_std_init(&context->std, concurrent_context_ce);
 	context->std.handlers = &concurrent_context_handlers;
-
-	GC_ADDREF(&context->std);
 
 	context->param_count = 1;
 
@@ -504,7 +498,7 @@ void concurrent_context_shutdown()
 	context = TASK_G(context);
 
 	if (context != NULL) {
-		concurrent_context_object_destroy(&context->std);
+		OBJ_RELEASE(&context->std);
 	}
 }
 

--- a/src/deferred.c
+++ b/src/deferred.c
@@ -259,35 +259,31 @@ static void concurrent_defer_combine_continuation(void *obj, zval *data, zval *r
 {
 	concurrent_defer_combine *combined;
 
-	zval args[4];
+	zval args[5];
 	zval retval;
 
 	combined = (concurrent_defer_combine *) obj;
 	combined->counter--;
 
 	ZVAL_OBJ(&args[0], &combined->defer->std);
-	ZVAL_COPY(&args[1], data);
+	ZVAL_BOOL(&args[1], combined->counter == 0);
+	ZVAL_COPY(&args[2], data);
 
 	if (success) {
-		ZVAL_NULL(&args[2]);
-		ZVAL_COPY(&args[3], result);
-
-		combined->fci.param_count = 4;
+		ZVAL_NULL(&args[3]);
+		ZVAL_COPY(&args[4], result);
 	} else {
-		ZVAL_COPY(&args[2], result);
-
-		combined->fci.param_count = 3;
+		ZVAL_COPY(&args[3], result);
+		ZVAL_NULL(&args[4]);
 	}
 
+	combined->fci.param_count = 5;
 	combined->fci.params = args;
 	combined->fci.retval = &retval;
 
 	zend_call_function(&combined->fci, &combined->fcc);
 
-	zval_ptr_dtor(&args[0]);
-	zval_ptr_dtor(&args[1]);
-	zval_ptr_dtor(&args[2]);
-	zval_ptr_dtor(&args[3]);
+	zval_ptr_dtor(args);
 	zval_ptr_dtor(&retval);
 
 	if (UNEXPECTED(EG(exception))) {

--- a/src/deferred.c
+++ b/src/deferred.c
@@ -246,6 +246,181 @@ ZEND_METHOD(Deferred, error)
 	RETURN_ZVAL(&obj, 1, 1);
 }
 
+typedef struct _concurrent_defer_combine concurrent_defer_combine;
+
+struct _concurrent_defer_combine {
+	concurrent_deferred *defer;
+	zend_long counter;
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+};
+
+static void concurrent_defer_combine_continuation(void *obj, zval *data, zval *result, zend_bool success)
+{
+	concurrent_defer_combine *combined;
+
+	zval args[4];
+	zval retval;
+
+	combined = (concurrent_defer_combine *) obj;
+	combined->counter--;
+
+	ZVAL_OBJ(&args[0], &combined->defer->std);
+	ZVAL_COPY(&args[1], data);
+
+	if (success) {
+		ZVAL_NULL(&args[2]);
+		ZVAL_COPY(&args[3], result);
+
+		combined->fci.param_count = 4;
+	} else {
+		ZVAL_COPY(&args[2], result);
+
+		combined->fci.param_count = 3;
+	}
+
+	combined->fci.params = args;
+	combined->fci.retval = &retval;
+
+	zend_call_function(&combined->fci, &combined->fcc);
+
+	zval_ptr_dtor(&args[0]);
+	zval_ptr_dtor(&args[1]);
+	zval_ptr_dtor(&args[2]);
+	zval_ptr_dtor(&args[3]);
+	zval_ptr_dtor(&retval);
+
+	if (UNEXPECTED(EG(exception))) {
+		if (combined->defer->status == CONCURRENT_DEFERRED_STATUS_PENDING) {
+			combined->defer->status = CONCURRENT_DEFERRED_STATUS_FAILED;
+
+			ZVAL_OBJ(&combined->defer->result, EG(exception));
+			EG(exception) = NULL;
+
+			concurrent_awaitable_trigger_continuation(&combined->defer->continuation, &combined->defer->result, 0);
+		} else {
+			EG(exception) = NULL;
+		}
+	}
+
+	if (combined->counter == 0) {
+		zval_ptr_dtor(&combined->fci.function_name);
+
+		if (combined->defer->status == CONCURRENT_DEFERRED_STATUS_PENDING) {
+			concurrent_awaitable_dispose_continuation(&combined->defer->continuation);
+		}
+
+		OBJ_RELEASE(&combined->defer->std);
+
+		efree(combined);
+	}
+}
+
+ZEND_METHOD(Deferred, combine)
+{
+	concurrent_deferred *defer;
+	concurrent_deferred_awaitable *awaitable;
+	concurrent_defer_combine *combined;
+	concurrent_task *task;
+	concurrent_deferred_awaitable *inner;
+
+	zend_class_entry *ce;
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+
+	zval *args;
+	zend_ulong i;
+	zend_string *k;
+	zval key;
+	zval *entry;
+	zval obj;
+
+	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2)
+		Z_PARAM_ARRAY(args)
+		Z_PARAM_FUNC_EX(fci, fcc, 1, 0)
+	ZEND_PARSE_PARAMETERS_END();
+
+	fci.no_separation = 1;
+
+	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(args), entry) {
+		if (Z_TYPE_P(entry) != IS_OBJECT) {
+			zend_throw_error(NULL, "All input elements must be awaitable");
+			return;
+		}
+
+		ce = Z_OBJCE_P(entry);
+
+		if (ce != concurrent_task_ce && ce != concurrent_deferred_awaitable_ce) {
+			zend_throw_error(NULL, "All input elements must be awaitable");
+			return;
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	defer = emalloc(sizeof(concurrent_deferred));
+	ZEND_SECURE_ZERO(defer, sizeof(concurrent_deferred));
+
+	zend_object_std_init(&defer->std, concurrent_deferred_ce);
+	defer->std.handlers = &concurrent_deferred_handlers;
+
+	defer->status = CONCURRENT_DEFERRED_STATUS_PENDING;
+
+	awaitable = concurrent_deferred_awaitable_object_create(defer);
+
+	ZVAL_OBJ(&obj, &awaitable->std);
+
+	combined = emalloc(sizeof(concurrent_defer_combine));
+	combined->defer = defer;
+	combined->counter = zend_array_count(Z_ARRVAL_P(args));
+	combined->fci = fci;
+	combined->fcc = fcc;
+
+	Z_TRY_ADDREF_P(&combined->fci.function_name);
+
+	ZEND_HASH_FOREACH_KEY_VAL_IND(Z_ARRVAL_P(args), i, k, entry) {
+		ce = Z_OBJCE_P(entry);
+
+		if (k == NULL) {
+			ZVAL_LONG(&key, i);
+		} else {
+			ZVAL_STR(&key, k);
+		}
+
+		if (ce == concurrent_task_ce) {
+			task = (concurrent_task *) Z_OBJ_P(entry);
+
+			if (task->fiber.status == CONCURRENT_FIBER_STATUS_FINISHED) {
+				concurrent_defer_combine_continuation(combined, &key, &task->result, 1);
+			} else if (task->fiber.status == CONCURRENT_FIBER_STATUS_DEAD) {
+				concurrent_defer_combine_continuation(combined, &key, &task->result, 0);
+			} else {
+				if (task->continuation == NULL) {
+					task->continuation = concurrent_awaitable_create_continuation(combined, &key, concurrent_defer_combine_continuation);
+				} else {
+					concurrent_awaitable_append_continuation(task->continuation, combined, &key, concurrent_defer_combine_continuation);
+				}
+			}
+		} else {
+			inner = (concurrent_deferred_awaitable *) Z_OBJ_P(entry);
+
+			if (inner->defer->status == CONCURRENT_DEFERRED_STATUS_RESOLVED) {
+				concurrent_defer_combine_continuation(combined, &key, &inner->defer->result, 1);
+			} else if (inner->defer->status == CONCURRENT_DEFERRED_STATUS_FAILED) {
+				concurrent_defer_combine_continuation(combined, &key, &inner->defer->result, 0);
+			} else {
+				if (inner->defer->continuation == NULL) {
+					inner->defer->continuation = concurrent_awaitable_create_continuation(combined, &key, concurrent_defer_combine_continuation);
+				} else {
+					concurrent_awaitable_append_continuation(inner->defer->continuation, combined, &key, concurrent_defer_combine_continuation);
+				}
+			}
+		}
+
+		zval_ptr_dtor(&key);
+	} ZEND_HASH_FOREACH_END();
+
+	RETURN_ZVAL(&obj, 1, 1);
+}
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_deferred_awaitable, 0, 0, Concurrent\\Awaitable, 0)
 ZEND_END_ARG_INFO()
 
@@ -265,12 +440,18 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_deferred_error, 0, 1, Concurrent\
 	ZEND_ARG_OBJ_INFO(0, error, Throwable, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_deferred_combine, 0, 2, Concurrent\\Awaitable, 0)
+	ZEND_ARG_ARRAY_INFO(0, params, 0)
+	ZEND_ARG_CALLABLE_INFO(0, continuation, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry deferred_functions[] = {
 	ZEND_ME(Deferred, awaitable, arginfo_deferred_awaitable, ZEND_ACC_PUBLIC)
 	ZEND_ME(Deferred, resolve, arginfo_deferred_resolve, ZEND_ACC_PUBLIC)
 	ZEND_ME(Deferred, fail, arginfo_deferred_fail, ZEND_ACC_PUBLIC)
 	ZEND_ME(Deferred, value, arginfo_deferred_value, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	ZEND_ME(Deferred, error, arginfo_deferred_error, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+	ZEND_ME(Deferred, combine, arginfo_deferred_combine, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	ZEND_FE_END
 };
 

--- a/src/deferred.c
+++ b/src/deferred.c
@@ -266,6 +266,8 @@ static void concurrent_defer_combine_continuation(void *obj, zval *data, zval *r
 	combined->counter--;
 
 	ZVAL_OBJ(&args[0], &combined->defer->std);
+	GC_ADDREF(&combined->defer->std);
+
 	ZVAL_BOOL(&args[1], combined->counter == 0);
 	ZVAL_COPY(&args[2], data);
 

--- a/src/task.c
+++ b/src/task.c
@@ -84,7 +84,7 @@ void concurrent_task_continue(concurrent_task *task)
 	}
 }
 
-static void concurrent_task_continuation(void *obj, zval *result, zend_bool success)
+static void concurrent_task_continuation(void *obj, zval *data, zval *result, zend_bool success)
 {
 	concurrent_task *task;
 
@@ -418,9 +418,9 @@ ZEND_METHOD(Task, await)
 		}
 
 		if (inner->continuation == NULL) {
-			inner->continuation = concurrent_awaitable_create_continuation(task, concurrent_task_continuation);
+			inner->continuation = concurrent_awaitable_create_continuation(task, NULL, concurrent_task_continuation);
 		} else {
-			concurrent_awaitable_append_continuation(inner->continuation, task, concurrent_task_continuation);
+			concurrent_awaitable_append_continuation(inner->continuation, task, NULL, concurrent_task_continuation);
 		}
 	} else if (ce == concurrent_deferred_awaitable_ce) {
 		defer = ((concurrent_deferred_awaitable *) Z_OBJ_P(val))->defer;
@@ -440,9 +440,9 @@ ZEND_METHOD(Task, await)
 		}
 
 		if (defer->continuation == NULL) {
-			defer->continuation = concurrent_awaitable_create_continuation(task, concurrent_task_continuation);
+			defer->continuation = concurrent_awaitable_create_continuation(task, NULL, concurrent_task_continuation);
 		} else {
-			concurrent_awaitable_append_continuation(defer->continuation, task, concurrent_task_continuation);
+			concurrent_awaitable_append_continuation(defer->continuation, task, NULL, concurrent_task_continuation);
 		}
 	} else {
 		RETURN_ZVAL(val, 1, 0);

--- a/src/task.c
+++ b/src/task.c
@@ -466,11 +466,6 @@ ZEND_METHOD(Task, await)
 
 	task->fiber.value = value;
 
-	if (task->fiber.status == CONCURRENT_FIBER_STATUS_DEAD) {
-		zend_throw_error(NULL, "Task has been destroyed");
-		return;
-	}
-
 	if (Z_TYPE_P(&task->error) != IS_UNDEF) {
 		error = task->error;
 		ZVAL_UNDEF(&task->error);
@@ -478,6 +473,13 @@ ZEND_METHOD(Task, await)
 		execute_data->opline--;
 		zend_throw_exception_internal(&error);
 		execute_data->opline++;
+
+		return;
+	}
+
+	if (task->fiber.status == CONCURRENT_FIBER_STATUS_DEAD) {
+		zend_throw_error(NULL, "Task has been destroyed");
+		return;
 	}
 }
 

--- a/src/task_scheduler.c
+++ b/src/task_scheduler.c
@@ -31,6 +31,9 @@ zend_class_entry *concurrent_task_scheduler_ce;
 
 static zend_object_handlers concurrent_task_scheduler_handlers;
 
+static zend_string *str_activate;
+static zend_string *str_runloop;
+
 
 concurrent_task_scheduler *concurrent_task_scheduler_get()
 {
@@ -97,8 +100,7 @@ zend_bool concurrent_task_scheduler_enqueue(concurrent_task *task)
 
 		ZVAL_OBJ(&obj, &scheduler->std);
 
-		zend_string *name = zend_string_init("activate", sizeof("activate")-1, 0);
-		zval *entry = zend_hash_find_ex(&scheduler->std.ce->function_table, name, 0);
+		zval *entry = zend_hash_find_ex(&scheduler->std.ce->function_table, str_activate, 1);
 		zend_function *func = Z_FUNC_P(entry);
 
 		zend_call_method_with_0_params(&obj, Z_OBJCE_P(&obj), &func, "activate", &retval);
@@ -120,8 +122,7 @@ void concurrent_task_scheduler_run_loop(concurrent_task_scheduler *scheduler)
 
 	ZVAL_OBJ(&obj, &scheduler->std);
 
-	zend_string *name = zend_string_init("runloop", sizeof("runloop")-1, 0);
-	zval *entry = zend_hash_find_ex(&scheduler->std.ce->function_table, name, 0);
+	zval *entry = zend_hash_find_ex(&scheduler->std.ce->function_table, str_runloop, 1);
 	zend_function *func = Z_FUNC_P(entry);
 
 	zend_call_method_with_0_params(&obj, Z_OBJCE_P(&obj), &func, "runloop", &retval);
@@ -460,6 +461,18 @@ void concurrent_task_scheduler_ce_register()
 	memcpy(&concurrent_task_scheduler_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	concurrent_task_scheduler_handlers.free_obj = concurrent_task_scheduler_object_destroy;
 	concurrent_task_scheduler_handlers.clone_obj = NULL;
+
+	str_activate = zend_string_init("activate", sizeof("activate")-1, 1);
+	str_runloop = zend_string_init("runloop", sizeof("runloop")-1, 1);
+
+	ZSTR_HASH(str_activate);
+	ZSTR_HASH(str_runloop);
+}
+
+void concurrent_task_scheduler_ce_unregister()
+{
+	zend_string_free(str_activate);
+	zend_string_free(str_runloop);
 }
 
 void concurrent_task_scheduler_shutdown()

--- a/tests/103-task-suspend.phpt
+++ b/tests/103-task-suspend.phpt
@@ -24,7 +24,7 @@ $scheduler->run(function () {
     
     Task::async(function () use ($defer) {
         $defer->resolve('D');
-        
+
         var_dump('C');
     });
 });

--- a/tests/300-deferred-api.phpt
+++ b/tests/300-deferred-api.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Deferred basic API.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+$scheduler = new TaskScheduler();
+
+$a = $scheduler->run(function () {
+	return Task::await(Deferred::value(321));
+});
+
+var_dump($a);
+
+try {
+    var_dump($scheduler->run(function () {
+        $e = Deferred::error(new \Error('Fail!'));
+    
+        var_dump('X');
+    
+        return Task::await($e);
+    }));
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
+
+$a = $scheduler->run(function () {
+    $defer = new Deferred();
+    
+    Task::async(function () use ($defer) {
+        var_dump('B');
+        
+        $defer->resolve(777);
+    });
+    
+    var_dump('A');
+    
+    return Task::await($defer->awaitable());
+});
+
+var_dump($a);
+
+?>
+--EXPECT--
+int(321)
+string(1) "X"
+string(5) "Fail!"
+string(1) "A"
+string(1) "B"
+int(777)

--- a/tests/301-deferred-combinator.phpt
+++ b/tests/301-deferred-combinator.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Deferred awaitable combinator API.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+$scheduler = new TaskScheduler();
+
+$a = $scheduler->run(function () {
+    var_dump('A');
+
+    return Task::await(Deferred::combine([
+        Deferred::value('D'),
+        Deferred::value(777)
+    ], function (Deferred $defer, bool $last, int $index, ?\Throwable $e, $v) {
+        var_dump('B');
+        var_dump($last);
+        var_dump($e);
+        $defer->resolve($v);
+        var_dump('C');
+    }));
+});
+
+var_dump($a);
+
+?>
+--EXPECT--
+string(1) "A"
+string(1) "B"
+bool(false)
+NULL
+string(1) "C"
+string(1) "B"
+bool(true)
+NULL
+string(1) "C"
+string(1) "D"

--- a/tests/302-deferred-combinator-fail.phpt
+++ b/tests/302-deferred-combinator-fail.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Deferred combinator ending with failure.
+--SKIPIF--
+<?php
+if (!extension_loaded('task')) echo 'Test requires the task extension to be loaded';
+?>
+--FILE--
+<?php
+
+namespace Concurrent;
+
+$scheduler = new TaskScheduler();
+
+try {
+    $scheduler->run(function () {
+        var_dump('A');
+
+        return Task::await(Deferred::combine([
+            Deferred::error(new \Error('Fail!'))
+        ], function (Deferred $defer, bool $last, int $index, ?\Throwable $e, $v) {
+            var_dump('B');
+            var_dump($last);
+            var_dump($v);
+            $defer->fail($e);
+            var_dump('C');
+        }));
+    });
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
+
+?>
+--EXPECT--
+string(1) "A"
+string(1) "B"
+bool(true)
+NULL
+string(1) "C"
+string(5) "Fail!"


### PR DESCRIPTION
This PR extends the `Deferred` class with a simple and efficient way to implement combinators that operate on multiple input `Awaitable` objects and provide a single output `Awaitable`. I suggested this in #14 which also explains why it more efficient than a userland solution using additional tasks.